### PR TITLE
Changed path to MunkiReport folder

### DIFF
--- a/scripts/filevaultstatus
+++ b/scripts/filevaultstatus
@@ -6,7 +6,7 @@ import sys
 import plistlib
 import platform
 import re
-sys.path.insert(0, '/usr/local/munki')
+sys.path.insert(0, '/usr/local/munkireport')
 
 from munkilib import FoundationPlist
 


### PR DESCRIPTION
Allows MunkiReport to run standalone without Munki.